### PR TITLE
🐛 FIX: The auth part of the npmrc setup had to be 'user:pass', and th…

### DIFF
--- a/art_conf/art_conf.py
+++ b/art_conf/art_conf.py
@@ -19,7 +19,7 @@ password: {password}
 
 def get_npmrc(art_url: str, user: str, password: str, email: str) -> str:
     user_pass = f"{user}:{password}"
-    b64_user_pass = base64.b64encode(user_pass.encode('ascii')).decode('ascii')
+    b64_user_pass = base64.b64encode(user_pass.encode("ascii")).decode("ascii")
     return f"""
 registry=https://{art_url}/npm/npm/
 _auth = {b64_user_pass}

--- a/art_conf/art_conf.py
+++ b/art_conf/art_conf.py
@@ -18,9 +18,11 @@ password: {password}
 
 
 def get_npmrc(art_url: str, user: str, password: str, email: str) -> str:
+    user_pass = f"{user}:{password}"
+    b64_user_pass = base64.b64encode(user_pass.encode('ascii')).decode('ascii')
     return f"""
 registry=https://{art_url}/npm/npm/
-_auth = {user}:{base64.b64encode(password.encode('ascii')).decode('ascii')}
+_auth = {b64_user_pass}
 email = {email}
 always-auth = true
 """


### PR DESCRIPTION
🐛 FIX: The auth part of the npmrc setup had to be 'user:pass', and then both things together were supposed to be b64 enconded